### PR TITLE
Added call to "encode()"

### DIFF
--- a/library/src/main/java/com/tandogan/geostuff/opencagedata/GeocodeRepositoryImpl.java
+++ b/library/src/main/java/com/tandogan/geostuff/opencagedata/GeocodeRepositoryImpl.java
@@ -100,6 +100,7 @@ public class GeocodeRepositoryImpl implements GeocodeRepository
                 .queryParam(API_KEY, apiKey)
                 .queryParam(QUERY, query)
                 .build()
+                .encode()
                 .toUri();
 
         LOGGER.debug("REST template is {}", template);


### PR DESCRIPTION
Encode all URI components using their specific encoding rules, and returns the result as a new UriComponents instance. This method uses UTF-8 to encode.